### PR TITLE
Fix update action for rolled back transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-## Unreleased
+## [0.3.0] - 2024-11-05
 
-- ...
+- Fix persistance in case of rolled back transactions.
 
 ## [0.2.0] - 2022-12-29
 
-- Allow to use a custom action name when tracking errors
+- Allow to use a custom action name when tracking errors.
 
 ## [0.1.0] - 2022-09-19
 
-- Initial release
+- Initial release.

--- a/lib/validation_errors.rb
+++ b/lib/validation_errors.rb
@@ -24,7 +24,7 @@ module ValidationErrors
     module InstanceMethods
       def save(**options)
         super.tap do |result|
-          ValidationError.track(self) unless result
+          Thread.new { ValidationError.track(self) }.join unless result
         end
       end
 
@@ -33,7 +33,7 @@ module ValidationErrors
       def save!(**options)
         super
       rescue ActiveRecord::RecordInvalid
-        ValidationError.track(self)
+        Thread.new { ValidationError.track(self) }.join
         raise
       end
     end

--- a/test/test_validation_error.rb
+++ b/test/test_validation_error.rb
@@ -55,4 +55,61 @@ class TestValidationError < Minitest::Test
     assert_equal "create", ValidationError.first.action
     assert_equal({"title" => [{"error" => "blank"}]}, ValidationError.first.details)
   end
+
+  def test_that_models_can_track_on_create
+    TrackedBook.create(title: "")
+    assert_equal 1, ValidationError.count
+    assert_equal "TrackedBook", ValidationError.first.invalid_model_name
+    assert_nil ValidationError.first.invalid_model_id
+    assert_equal "create", ValidationError.first.action
+    assert_equal({"title" => [{"error" => "blank"}]}, ValidationError.first.details)
+  end
+
+  def test_that_models_can_track_on_create_bang
+    begin
+      TrackedBook.create!(title: "")
+    rescue
+      ActiveRecord::RecordInvalid
+    end
+    assert_equal 1, ValidationError.count
+    assert_equal "TrackedBook", ValidationError.first.invalid_model_name
+    assert_nil ValidationError.first.invalid_model_id
+    assert_equal "create", ValidationError.first.action
+    assert_equal({"title" => [{"error" => "blank"}]}, ValidationError.first.details)
+  end
+
+  def test_that_models_do_not_track_on_create_if_no_errors
+    TrackedBook.create(title: "The Hobbit")
+    assert_equal 0, ValidationError.count
+  end
+
+  def test_that_models_can_track_on_update
+    book = TrackedBook.create(title: "The Hobbit")
+    book.update(title: "")
+    assert_equal 1, ValidationError.count
+    assert_equal "TrackedBook", ValidationError.first.invalid_model_name
+    assert_equal book.id, ValidationError.first.invalid_model_id
+    assert_equal "update", ValidationError.first.action
+    assert_equal({"title" => [{"error" => "blank"}]}, ValidationError.first.details)
+  end
+
+  def test_that_models_can_track_on_update_bang
+    book = TrackedBook.create(title: "The Hobbit")
+    begin
+      book.update!(title: "")
+    rescue
+      ActiveRecord::RecordInvalid
+    end
+    assert_equal 1, ValidationError.count
+    assert_equal "TrackedBook", ValidationError.first.invalid_model_name
+    assert_equal book.id, ValidationError.first.invalid_model_id
+    assert_equal "update", ValidationError.first.action
+    assert_equal({"title" => [{"error" => "blank"}]}, ValidationError.first.details)
+  end
+
+  def test_that_models_do_not_track_on_update_if_no_errors
+    book = TrackedBook.create(title: "The Hobbit")
+    book.update(title: "Harry Potter")
+    assert_equal 0, ValidationError.count
+  end
 end


### PR DESCRIPTION
Thanks @simon-isler for #2 . I decided to use a different approach to be sure to cover all cases. I needed to track outside of the current transaction.